### PR TITLE
Add basic Arq structure decoding support.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1,0 +1,197 @@
+package arq
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+)
+
+var (
+	ErrUnimplemented      = errors.New("Unimplemented")
+	ErrUnknownSliceLength = errors.New("ErrUnknownSliceLength")
+	ErrTooLong            = errors.New("value contains too many elements")
+)
+
+type ArqUnmarshaler interface {
+	UnmarshalArq(io.Reader) error
+}
+
+func DecodeArq(r io.Reader, i interface{}) error {
+	// If this type knows how to decode itself, let it.
+	if um, ok := i.(ArqUnmarshaler); ok {
+		return um.UnmarshalArq(r)
+	}
+
+	return decodeArqValue(r, reflect.ValueOf(i).Elem(), "")
+}
+
+func decodeArqValue(r io.Reader, v reflect.Value, tag string) error {
+	switch v.Kind() {
+	case reflect.Int8:
+		var n int8
+		err := binary.Read(r, binary.BigEndian, &n)
+		if err != nil {
+			return err
+		}
+		v.SetInt(int64(n))
+		return nil
+	case reflect.Int32:
+		var n int32
+		err := binary.Read(r, binary.BigEndian, &n)
+		if err != nil {
+			return err
+		}
+		v.SetInt(int64(n))
+		return nil
+	case reflect.Int64:
+		var n int64
+		err := binary.Read(r, binary.BigEndian, &n)
+		if err != nil {
+			return err
+		}
+		v.SetInt(n)
+		return nil
+	case reflect.Uint8:
+		var n uint8
+		err := binary.Read(r, binary.BigEndian, &n)
+		if err != nil {
+			return err
+		}
+		v.SetUint(uint64(n))
+		return nil
+	case reflect.Uint32:
+		var n uint32
+		err := binary.Read(r, binary.BigEndian, &n)
+		if err != nil {
+			return err
+		}
+		v.SetUint(uint64(n))
+		return nil
+	case reflect.Uint64:
+		var n uint64
+		err := binary.Read(r, binary.BigEndian, &n)
+		if err != nil {
+			return err
+		}
+		v.SetUint(n)
+		return nil
+	case reflect.Bool:
+		var n uint8
+		err := binary.Read(r, binary.BigEndian, &n)
+		if err != nil {
+			return err
+		}
+		v.SetBool(n == 1)
+		return nil
+	case reflect.Array:
+		// byte arrays are special cased because we use them so often.
+		if v.Type().Elem().Kind() == reflect.Uint8 {
+			return decodeByteArray(r, v)
+		}
+		// Otherwise, recurse for each element.
+		for i := 0; i < v.Len(); i++ {
+			err := decodeArqValue(r, v.Index(i), "")
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	case reflect.String:
+		return decodeString(r, v)
+	case reflect.Struct:
+		return decodeStruct(r, v, tag)
+	case reflect.Slice:
+		return decodeSlice(r, v, tag)
+	}
+	return fmt.Errorf("decoding '%s' %w", v.Type().String(), ErrUnimplemented)
+}
+
+func decodeByteArray(r io.Reader, v reflect.Value) error {
+	buf := make([]byte, v.Len())
+	_, err := io.ReadAtLeast(r, buf, v.Len())
+	if err != nil {
+		return err
+	}
+	reflect.Copy(v, reflect.ValueOf(buf))
+	return nil
+}
+
+func decodeString(r io.Reader, v reflect.Value) error {
+	notNull := byte(0)
+	if err := binary.Read(r, binary.BigEndian, &notNull); err != nil {
+		return err
+	}
+	if notNull != 1 {
+		return nil
+	}
+	length := uint64(0)
+	if err := binary.Read(r, binary.BigEndian, &length); err != nil {
+		return err
+	}
+	if length > 4096 {
+		return ErrTooLong
+	}
+	buf := make([]byte, length)
+	if _, err := io.ReadAtLeast(r, buf, int(length)); err != nil {
+		return err
+	}
+	v.SetString(string(buf))
+	return nil
+}
+
+func decodeStruct(r io.Reader, v reflect.Value, tag string) error {
+	for i := 0; i < v.NumField(); i++ {
+		if !v.Field(i).CanSet() {
+			continue
+		}
+		err := decodeArqValue(r, v.Field(i), v.Type().Field(i).Tag.Get("arq"))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func decodeSlice(r io.Reader, v reflect.Value, tag string) error {
+	// Determine the number of elements in the slice.
+	var n uint64
+	switch tag {
+	case "len-uint32":
+		var n32 uint32
+		err := binary.Read(r, binary.BigEndian, &n32)
+		if err != nil {
+			return err
+		}
+		n = uint64(n32)
+	case "len-uint64":
+		err := binary.Read(r, binary.BigEndian, &n)
+		if err != nil {
+			return err
+		}
+	default:
+		return ErrUnknownSliceLength
+	}
+	if n > 4096 {
+		return ErrTooLong
+	}
+	// Fast path for bytes to avoid recursing.
+	if v.Type().Elem().Kind() == reflect.Uint8 {
+		buf := make([]byte, int(n))
+		_, err := io.ReadAtLeast(r, buf, int(n))
+		if err != nil {
+			return err
+		}
+		v.Set(reflect.AppendSlice(v, reflect.ValueOf(buf)))
+		return nil
+	}
+	for i := 0; i < int(n); i++ {
+		elem := reflect.New(v.Type().Elem()).Elem()
+		if err := decodeArqValue(r, elem, ""); err != nil {
+			return err
+		}
+		v.Set(reflect.Append(v, elem))
+	}
+	return nil
+}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,0 +1,239 @@
+package arq_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/sholiday/arq"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeBasic(t *testing.T) {
+	t.Run("int8", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		expected := int8(42)
+		err := binary.Write(buf, binary.BigEndian, expected)
+		if !assert.Nil(t, err) {
+			return
+		}
+		var actual int8
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("int32", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		expected := int32(42)
+		err := binary.Write(buf, binary.BigEndian, expected)
+		if !assert.Nil(t, err) {
+			return
+		}
+		var actual int32
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("int64", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		expected := int64(42)
+		err := binary.Write(buf, binary.BigEndian, expected)
+		if !assert.Nil(t, err) {
+			return
+		}
+		var actual int64
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("uint8", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		expected := uint8(42)
+		err := binary.Write(buf, binary.BigEndian, expected)
+		if !assert.Nil(t, err) {
+			return
+		}
+		var actual uint8
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("uint32", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		expected := uint32(42)
+		err := binary.Write(buf, binary.BigEndian, expected)
+		if !assert.Nil(t, err) {
+			return
+		}
+		var actual uint32
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("uint64", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		expected := uint64(42)
+		err := binary.Write(buf, binary.BigEndian, expected)
+		if !assert.Nil(t, err) {
+			return
+		}
+		var actual uint64
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("bool", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		expected := true
+		err := binary.Write(buf, binary.BigEndian, uint8(1))
+		if !assert.Nil(t, err) {
+			return
+		}
+		var actual bool
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+}
+
+func TestDecodeArray(t *testing.T) {
+	t.Run("byte-array", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		expected := [4]byte{0xFE, 0xED, 0xFA, 0xCE}
+		err := binary.Write(buf, binary.BigEndian, expected)
+		if !assert.Nil(t, err) {
+			return
+		}
+		var actual [4]byte
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("uint32-array", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		expected := [4]uint32{1, 2, 3, 4}
+		err := binary.Write(buf, binary.BigEndian, expected)
+		if !assert.Nil(t, err) {
+			return
+		}
+		var actual [4]uint32
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+}
+
+func TestDecodeString(t *testing.T) {
+	testCases := []struct {
+		name          string
+		notNull       uint8
+		length        uint64
+		values        []byte
+		expected      string
+		expectedError error
+	}{
+		{"Basic", 1, 4, []byte("arq!"), "arq!", nil},
+		{"Null", 0, 0, []byte{}, "", nil},
+		{"NullWithData", 0, 4, []byte("arq!"), "", nil},
+		{"Length", 1, 3, []byte("arq!"), "arq", nil},
+
+		// These should all return an error.
+		{"Eof", 1, 100, []byte("arq!"), "", io.ErrUnexpectedEOF},
+		{"TooLarge", 1, 5000, make([]byte, 5000), "", arq.ErrTooLong},
+	}
+
+	for _, tCase := range testCases {
+		t.Run(tCase.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			assert.Nil(t, binary.Write(buf, binary.BigEndian, tCase.notNull))
+			if tCase.notNull == 1 {
+				assert.Nil(t, binary.Write(buf, binary.BigEndian, tCase.length))
+				assert.Nil(t, binary.Write(buf, binary.BigEndian, tCase.values))
+			}
+			var actual string
+			err := arq.DecodeArq(buf, &actual)
+			assert.Equal(t, err, tCase.expectedError)
+			assert.Equal(t, tCase.expected, actual)
+		})
+	}
+}
+
+func TestDecodeStruct(t *testing.T) {
+	type testStruct struct {
+		B   bool
+		By  byte
+		U32 uint32
+	}
+	expected := testStruct{false, 0xFF, 94043}
+	buf := new(bytes.Buffer)
+	assert.Nil(t, binary.Write(buf, binary.BigEndian, expected))
+	var actual testStruct
+	assert.Nil(t, arq.DecodeArq(buf, &actual))
+	assert.Equal(t, expected, actual)
+}
+
+func TestDecodeSlice(t *testing.T) {
+	t.Run("BytesLen32", func(t *testing.T) {
+		type testStruct struct {
+			By []byte `arq:"len-uint32"`
+		}
+		expected := testStruct{[]byte("arq!")}
+		buf := new(bytes.Buffer)
+		assert.Nil(t, binary.Write(buf, binary.BigEndian, uint32(4)))
+		assert.Nil(t, binary.Write(buf, binary.BigEndian, []byte("arq!")))
+
+		var actual testStruct
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("BytesLen64", func(t *testing.T) {
+		type testStruct struct {
+			By []byte `arq:"len-uint64"`
+		}
+		expected := testStruct{[]byte("arq!")}
+		buf := new(bytes.Buffer)
+		assert.Nil(t, binary.Write(buf, binary.BigEndian, uint64(4)))
+		assert.Nil(t, binary.Write(buf, binary.BigEndian, []byte("arq!")))
+
+		var actual testStruct
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Int32sLen32", func(t *testing.T) {
+		type testStruct struct {
+			By []int32 `arq:"len-uint32"`
+		}
+		expected := testStruct{[]int32{94040, 94043}}
+		buf := new(bytes.Buffer)
+		assert.Nil(t, binary.Write(buf, binary.BigEndian, uint32(2)))
+		assert.Nil(t, binary.Write(buf, binary.BigEndian, int32(94040)))
+		assert.Nil(t, binary.Write(buf, binary.BigEndian, int32(94043)))
+
+		var actual testStruct
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("Int32sLen64", func(t *testing.T) {
+		type testStruct struct {
+			By []int32 `arq:"len-uint64"`
+		}
+		expected := testStruct{[]int32{94040, 94043}}
+		buf := new(bytes.Buffer)
+		assert.Nil(t, binary.Write(buf, binary.BigEndian, uint64(2)))
+		assert.Nil(t, binary.Write(buf, binary.BigEndian, int32(94040)))
+		assert.Nil(t, binary.Write(buf, binary.BigEndian, int32(94043)))
+
+		var actual testStruct
+		assert.Nil(t, arq.DecodeArq(buf, &actual))
+		assert.Equal(t, expected, actual)
+	})
+}
+
+type testUnmarshalable struct {
+	MyValue string
+}
+
+func (ts *testUnmarshalable) UnmarshalArq(r io.Reader) error {
+	ts.MyValue = "arq!"
+	return nil
+}
+
+func TestDecodeArqUnmarshaler(t *testing.T) {
+	expected := testUnmarshalable{"arq!"}
+	buf := new(bytes.Buffer)
+	var actual testUnmarshalable
+	assert.Nil(t, arq.DecodeArq(buf, &actual))
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
This change adds support to decode some basic types (ints, uints, bytes,
slices, arrays, and strings) and structs containing those basic types
(recursively).

Decoding also supports structures that know how to decode themselves
using the UnmarshalArq interface.